### PR TITLE
At the moment any errors happening downstream of this module will res…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,10 @@ export default (options: Options) => {
       try {
         ctx.userinfo = await requestUserinfo(options.site, token)
         debug('userinfo', ctx.userinfo)
-        await next()
       } catch (err) {
         return ctx.throw(401, err)
       }
+      await next();
     }
 
   }


### PR DESCRIPTION
…ult in a 401 error.

Moved "next()" out of try block so that errors can rather be handled by app using this module.
Only real userinfo related errors will now result in a 401 error.